### PR TITLE
Refactor to support ESP32-Arduino-CAN

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Simple library for IVT shunts.
 Based on the EVTV library of 2016, revised for use with CHAdeMO.
 Originally intended to integrate with Arduino Due.
 Adapted for ESP32 and ESP32-Arduino-CAN for use in the Battery-Emulator project https://github.com/dalathegreat/Battery-Emulator
+    hosted at https://github.com/smaresca/SimpleISA-ESP32-Arduino-CAN
 
 Derived from https://github.com/isaac96/simpleISA/ and https://github.com/damienmaguire/SimpleISA/
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # SimpleISA
 Simple library for IVT shunts. 
 Based on the EVTV library of 2016, revised for use with CHAdeMO.
-Compatible with Arduino Due
+Originally intended to integrate with Arduino Due.
+Adapted for ESP32 and ESP32-Arduino-CAN for use in the Battery-Emulator project https://github.com/dalathegreat/Battery-Emulator
+
+Derived from https://github.com/isaac96/simpleISA/ and https://github.com/damienmaguire/SimpleISA/
+

--- a/SimpleISA.cpp
+++ b/SimpleISA.cpp
@@ -6,11 +6,13 @@
     copyright 2014
     You are licensed to use this library for any purpose, commercial or private, 
     without restriction.
+
+    2024 - Modified to make use of ESP32-Arduino-CAN by miwagner
     
 */
 
 
-#include <SimpleISA.h>
+#include "SimpleISA.h"
 
 template<class T> inline Print &operator <<(Print &obj, T arg) { obj.print(arg); return obj; } 
 
@@ -33,36 +35,18 @@ ISA::~ISA() //Define destructor
 void ISA::begin(int Port, int speed)
 {
   
- if (Port == 0)
-  {
-    canPort = &Can0;
-	  canEnPin = 255;
-	  canSpeed = speed * 1000;
-  }
-  else
-  {
-      canPort = &Can1;
-	  canEnPin = 255;
-	  canSpeed = speed * 1000;
-      
-  }
-
-  canPort->begin(canSpeed, canEnPin);
-  canPort->attachObj(this);
-  attachMBHandler(0);
-  //initCurrent();  
   
 }
 
 
 
-void ISA::gotFrame(CAN_FRAME *frame, int mailbox)
+void ISA::handleFrame(CAN_frame_t *frame)
  
 //This is our CAN interrupt service routine to catch inbound frames
 {
 
 
-   switch (frame->id)
+   switch (frame->MsgID)
      {
      case 0x511:
       
@@ -104,12 +88,12 @@ void ISA::gotFrame(CAN_FRAME *frame, int mailbox)
      if(debug)printCAN(frame);
 }
 
-void ISA::handle521(CAN_FRAME *frame)  //AMperes
+void ISA::handle521(CAN_frame_t *frame)  //AMperes
 
 {	
 	framecount++;
 	long current=0;
-    current = (long)((frame->data.bytes[5] << 24) | (frame->data.bytes[4] << 16) | (frame->data.bytes[3] << 8) | (frame->data.bytes[2]));
+    current = (long)((frame->data.u8[5] << 24) | (frame->data.u8[4] << 16) | (frame->data.u8[3] << 8) | (frame->data.u8[2]));
     
     milliamps=current;
     Amperes=current/1000.0f;
@@ -118,12 +102,12 @@ void ISA::handle521(CAN_FRAME *frame)  //AMperes
     	
 }
 
-void ISA::handle522(CAN_FRAME *frame)  //Voltage
+void ISA::handle522(CAN_frame_t *frame)  //Voltage
 
 {	
 	framecount++;
 	long volt=0;
-    volt = (long)((frame->data.bytes[5] << 24) | (frame->data.bytes[4] << 16) | (frame->data.bytes[3] << 8) | (frame->data.bytes[2]));
+    volt = (long)((frame->data.u8[5] << 24) | (frame->data.u8[4] << 16) | (frame->data.u8[3] << 8) | (frame->data.u8[2]));
     
     Voltage=volt/1000.0f;
 	Voltage1=Voltage-(Voltage2+Voltage3);
@@ -141,12 +125,12 @@ void ISA::handle522(CAN_FRAME *frame)  //Voltage
      	
 }
 
-void ISA::handle523(CAN_FRAME *frame) //Voltage2
+void ISA::handle523(CAN_frame_t *frame) //Voltage2
 
 {	
 	framecount++;
 	long volt=0;
-    volt = (long)((frame->data.bytes[5] << 24) | (frame->data.bytes[4] << 16) | (frame->data.bytes[3] << 8) | (frame->data.bytes[2]));
+    volt = (long)((frame->data.u8[5] << 24) | (frame->data.u8[4] << 16) | (frame->data.u8[3] << 8) | (frame->data.u8[2]));
     
     Voltage2=volt/1000.0f;
     if(Voltage2>3)Voltage2-=Voltage3;
@@ -160,12 +144,12 @@ void ISA::handle523(CAN_FRAME *frame) //Voltage2
    	
 }
 
-void ISA::handle524(CAN_FRAME *frame)  //Voltage3
+void ISA::handle524(CAN_frame_t *frame)  //Voltage3
 
 {	
 	framecount++;
 	long volt=0;
-    volt = (long)((frame->data.bytes[5] << 24) | (frame->data.bytes[4] << 16) | (frame->data.bytes[3] << 8) | (frame->data.bytes[2]));
+    volt = (long)((frame->data.u8[5] << 24) | (frame->data.u8[4] << 16) | (frame->data.u8[3] << 8) | (frame->data.u8[2]));
     
     Voltage3=volt/1000.0f;
     if(framecount<150)Voltage3LO=Voltage3;
@@ -175,12 +159,12 @@ void ISA::handle524(CAN_FRAME *frame)  //Voltage3
      if(debug2)Serial<<"Voltage: "<<Voltage<<" vdc Voltage 3: "<<Voltage3<<" vdc "<<volt<<" mVdc frames:"<<framecount<<"\n";
 }
 
-void ISA::handle525(CAN_FRAME *frame)  //Temperature
+void ISA::handle525(CAN_frame_t *frame)  //Temperature
 
 {	
 	framecount++;
 	long temp=0;
-    temp = (long)((frame->data.bytes[5] << 24) | (frame->data.bytes[4] << 16) | (frame->data.bytes[3] << 8) | (frame->data.bytes[2]));
+    temp = (long)((frame->data.u8[5] << 24) | (frame->data.u8[4] << 16) | (frame->data.u8[3] << 8) | (frame->data.u8[2]));
     
     Temperature=temp/10;
 		
@@ -190,12 +174,12 @@ void ISA::handle525(CAN_FRAME *frame)  //Temperature
 
 
 
-void ISA::handle526(CAN_FRAME *frame) //Kilowatts
+void ISA::handle526(CAN_frame_t *frame) //Kilowatts
 
 {	
 	framecount++;
 	watt=0;
-    watt = (long)((frame->data.bytes[5] << 24) | (frame->data.bytes[4] << 16) | (frame->data.bytes[3] << 8) | (frame->data.bytes[2]));
+    watt = (long)((frame->data.u8[5] << 24) | (frame->data.u8[4] << 16) | (frame->data.u8[3] << 8) | (frame->data.u8[2]));
     
     KW=watt/1000.0f;
 		
@@ -204,12 +188,12 @@ void ISA::handle526(CAN_FRAME *frame) //Kilowatts
 }
 
 
-void ISA::handle527(CAN_FRAME *frame) //Ampere-Hours
+void ISA::handle527(CAN_frame_t *frame) //Ampere-Hours
 
 {	
 	framecount++;
 	As=0;
-    As = (frame->data.bytes[5] << 24) | (frame->data.bytes[4] << 16) | (frame->data.bytes[3] << 8) | (frame->data.bytes[2]);
+    As = (frame->data.u8[5] << 24) | (frame->data.u8[4] << 16) | (frame->data.u8[3] << 8) | (frame->data.u8[2]);
     
     AH+=(As-lastAs)/3600.0f;
     lastAs=As;
@@ -219,12 +203,12 @@ void ISA::handle527(CAN_FRAME *frame) //Ampere-Hours
     
 }
 
-void ISA::handle528(CAN_FRAME *frame)  //kiloWatt-hours
+void ISA::handle528(CAN_frame_t *frame)  //kiloWatt-hours
 
 {	
 	framecount++;
 	
-    wh = (long)((frame->data.bytes[5] << 24) | (frame->data.bytes[4] << 16) | (frame->data.bytes[3] << 8) | (frame->data.bytes[2]));
+    wh = (long)((frame->data.u8[5] << 24) | (frame->data.u8[4] << 16) | (frame->data.u8[3] << 8) | (frame->data.u8[2]));
     KWH+=(wh-lastWh)/1000.0f;
 	lastWh=wh;
      if(debug2)Serial<<"KiloWattHours: "<<KWH<<"  Watt Hours: "<<wh<<" frames:"<<framecount<<"\n";
@@ -232,7 +216,7 @@ void ISA::handle528(CAN_FRAME *frame)  //kiloWatt-hours
 }
 
 
-void ISA::printCAN(CAN_FRAME *frame)
+void ISA::printCAN(CAN_frame_t *frame)
 {
 	
    //This routine simply prints a timestamp and the contents of the 
@@ -245,8 +229,8 @@ void ISA::printCAN(CAN_FRAME *frame)
 	sprintf(buffer,"%02d:%02d:%02d.%03d", hours, minutes, seconds, milliseconds);
 	Serial<<buffer<<" ";
     sprintf(bigbuffer,"%02X %02X %02X %02X %02X %02X %02X %02X %02X", 
-    frame->id, frame->data.bytes[0],frame->data.bytes[1],frame->data.bytes[2],
-    frame->data.bytes[3],frame->data.bytes[4],frame->data.bytes[5],frame->data.bytes[6],frame->data.bytes[7],0);
+    frame->MsgID, frame->data.u8[0],frame->data.u8[1],frame->data.u8[2],
+    frame->data.u8[3],frame->data.u8[4],frame->data.u8[5],frame->data.u8[6],frame->data.u8[7],0);
     Serial<<"Rcvd ISA frame: 0x"<<bigbuffer<<"\n";
     
 }
@@ -262,20 +246,16 @@ void ISA::initialize()
 	
 Serial.println("initialization \n");
 	
-	outframe.id = 0x411;      // Set our transmission address ID
-        outframe.length = 8;       // Data payload 8 bytes
-        outframe.extended = 0; // Extended addresses  0=11-bit1=29bit
-        outframe.rtr=1;                 //No request
-        outframe.data.bytes[0]=(0x20+i);
-        outframe.data.bytes[1]=0x42;  
-        outframe.data.bytes[2]=0x02;
-        outframe.data.bytes[3]=(0x60+(i*18));
-        outframe.data.bytes[4]=0x00;
-        outframe.data.bytes[5]=0x00;
-        outframe.data.bytes[6]=0x00;
-        outframe.data.bytes[7]=0x00;
+        outframe.data.u8[0]=(0x20+i);
+        outframe.data.u8[1]=0x42;  
+        outframe.data.u8[2]=0x02;
+        outframe.data.u8[3]=(0x60+(i*18));
+        outframe.data.u8[4]=0x00;
+        outframe.data.u8[5]=0x00;
+        outframe.data.u8[6]=0x00;
+        outframe.data.u8[7]=0x00;
 
-	   canPort->sendFrame(outframe);
+	   ESP32Can.CANWriteFrame(&outframe);
      
        if(debug)printCAN(&outframe);
 	   delay(500);
@@ -297,19 +277,15 @@ void ISA::STOP()
 
 //SEND STOP///////
 
-	    outframe.id = 0x411;      // Set our transmission address ID
-        outframe.length = 8;       // Data payload 8 bytes
-        outframe.extended = 0; // Extended addresses  0=11-bit1=29bit
-        outframe.rtr=1;                 //No request
-        outframe.data.bytes[0]=0x34;
-        outframe.data.bytes[1]=0x00;  
-        outframe.data.bytes[2]=0x01;
-        outframe.data.bytes[3]=0x00;
-        outframe.data.bytes[4]=0x00;
-        outframe.data.bytes[5]=0x00;
-        outframe.data.bytes[6]=0x00;
-        outframe.data.bytes[7]=0x00;
-		canPort->sendFrame(outframe);
+        outframe.data.u8[0]=0x34;
+        outframe.data.u8[1]=0x00;  
+        outframe.data.u8[2]=0x01;
+        outframe.data.u8[3]=0x00;
+        outframe.data.u8[4]=0x00;
+        outframe.data.u8[5]=0x00;
+        outframe.data.u8[6]=0x00;
+        outframe.data.u8[7]=0x00;
+		ESP32Can.CANWriteFrame(&outframe);
      
         if(debug) {printCAN(&outframe);} //If the debug variable is set, show our transmitted frame
 } 
@@ -318,19 +294,15 @@ void ISA::sendSTORE()
 
 //SEND STORE///////
 
-	outframe.id = 0x411;      // Set our transmission address ID
-        outframe.length = 8;       // Data payload 8 bytes
-        outframe.extended = 0; // Extended addresses  0=11-bit1=29bit
-        outframe.rtr=1;                 //No request
-        outframe.data.bytes[0]=0x32;
-        outframe.data.bytes[1]=0x00;  
-        outframe.data.bytes[2]=0x00;
-        outframe.data.bytes[3]=0x00;
-        outframe.data.bytes[4]=0x00;
-        outframe.data.bytes[5]=0x00;
-        outframe.data.bytes[6]=0x00;
-        outframe.data.bytes[7]=0x00;
-		canPort->sendFrame(outframe);
+        outframe.data.u8[0]=0x32;
+        outframe.data.u8[1]=0x00;  
+        outframe.data.u8[2]=0x00;
+        outframe.data.u8[3]=0x00;
+        outframe.data.u8[4]=0x00;
+        outframe.data.u8[5]=0x00;
+        outframe.data.u8[6]=0x00;
+        outframe.data.u8[7]=0x00;
+		ESP32Can.CANWriteFrame(&outframe);
      
         if(debug)printCAN(&outframe); //If the debug variable is set, show our transmitted frame
         
@@ -341,19 +313,15 @@ void ISA::START()
            
  //SEND START///////
 
-	    outframe.id = 0x411;      // Set our transmission address ID
-        outframe.length = 8;       // Data payload 8 bytes
-        outframe.extended = 0; // Extended addresses  0=11-bit1=29bit
-        outframe.rtr=1;                 //No request
-        outframe.data.bytes[0]=0x34;
-        outframe.data.bytes[1]=0x01;  
-        outframe.data.bytes[2]=0x01;
-        outframe.data.bytes[3]=0x00;
-        outframe.data.bytes[4]=0x00;
-        outframe.data.bytes[5]=0x00;
-        outframe.data.bytes[6]=0x00;
-        outframe.data.bytes[7]=0x00;
-		canPort->sendFrame(outframe);
+        outframe.data.u8[0]=0x34;
+        outframe.data.u8[1]=0x01;  
+        outframe.data.u8[2]=0x01;
+        outframe.data.u8[3]=0x00;
+        outframe.data.u8[4]=0x00;
+        outframe.data.u8[5]=0x00;
+        outframe.data.u8[6]=0x00;
+        outframe.data.u8[7]=0x00;
+		ESP32Can.CANWriteFrame(&outframe);
      
         if(debug)printCAN(&outframe); //If the debug variable is set, show our transmitted frame
 }
@@ -362,19 +330,15 @@ void ISA::RESTART()
 {
          //Has the effect of zeroing AH and KWH  
 
-	    outframe.id = 0x411;      // Set our transmission address ID
-        outframe.length = 8;       // Data payload 8 bytes
-        outframe.extended = 0; // Extended addresses  0=11-bit1=29bit
-        outframe.rtr=1;                 //No request
-        outframe.data.bytes[0]=0x3F;
-        outframe.data.bytes[1]=0x00;  
-        outframe.data.bytes[2]=0x00;
-        outframe.data.bytes[3]=0x00;
-        outframe.data.bytes[4]=0x00;
-        outframe.data.bytes[5]=0x00;
-        outframe.data.bytes[6]=0x00;
-        outframe.data.bytes[7]=0x00;
-		canPort->sendFrame(outframe);
+        outframe.data.u8[0]=0x3F;
+        outframe.data.u8[1]=0x00;  
+        outframe.data.u8[2]=0x00;
+        outframe.data.u8[3]=0x00;
+        outframe.data.u8[4]=0x00;
+        outframe.data.u8[5]=0x00;
+        outframe.data.u8[6]=0x00;
+        outframe.data.u8[7]=0x00;
+		ESP32Can.CANWriteFrame(&outframe);
      
         if(debug)printCAN(&outframe); //If the debug variable is set, show our transmitted frame
 }
@@ -384,19 +348,15 @@ void ISA::deFAULT()
 {
          //Returns module to original defaults  
 
-	    outframe.id = 0x411;      // Set our transmission address ID
-        outframe.length = 8;       // Data payload 8 bytes
-        outframe.extended = 0; // Extended addresses  0=11-bit1=29bit
-        outframe.rtr=1;                 //No request
-        outframe.data.bytes[0]=0x3D;
-        outframe.data.bytes[1]=0x00;  
-        outframe.data.bytes[2]=0x00;
-        outframe.data.bytes[3]=0x00;
-        outframe.data.bytes[4]=0x00;
-        outframe.data.bytes[5]=0x00;
-        outframe.data.bytes[6]=0x00;
-        outframe.data.bytes[7]=0x00;
-		canPort->sendFrame(outframe);
+        outframe.data.u8[0]=0x3D;
+        outframe.data.u8[1]=0x00;  
+        outframe.data.u8[2]=0x00;
+        outframe.data.u8[3]=0x00;
+        outframe.data.u8[4]=0x00;
+        outframe.data.u8[5]=0x00;
+        outframe.data.u8[6]=0x00;
+        outframe.data.u8[7]=0x00;
+		ESP32Can.CANWriteFrame(&outframe);
      
         if(debug)printCAN(&outframe); //If the debug variable is set, show our transmitted frame
 }
@@ -410,20 +370,16 @@ void ISA::initCurrent()
 	
 Serial.println("initialization \n");
 	
-	outframe.id = 0x411;      // Set our transmission address ID
-        outframe.length = 8;       // Data payload 8 bytes
-        outframe.extended = 0; // Extended addresses  0=11-bit1=29bit
-        outframe.rtr=1;                 //No request
-        outframe.data.bytes[0]=(0x21);
-        outframe.data.bytes[1]=0x42;  
-        outframe.data.bytes[2]=0x01;
-        outframe.data.bytes[3]=(0x61);
-        outframe.data.bytes[4]=0x00;
-        outframe.data.bytes[5]=0x00;
-        outframe.data.bytes[6]=0x00;
-        outframe.data.bytes[7]=0x00;
+        outframe.data.u8[0]=(0x21);
+        outframe.data.u8[1]=0x42;  
+        outframe.data.u8[2]=0x01;
+        outframe.data.u8[3]=(0x61);
+        outframe.data.u8[4]=0x00;
+        outframe.data.u8[5]=0x00;
+        outframe.data.u8[6]=0x00;
+        outframe.data.u8[7]=0x00;
 
-		canPort->sendFrame(outframe);
+		ESP32Can.CANWriteFrame(&outframe);
      
        if(debug)printCAN(&outframe);
 	delay(500);

--- a/SimpleISA.h
+++ b/SimpleISA.h
@@ -9,13 +9,10 @@
     
 */ 
 #include <Arduino.h>
-#include <DueTimer.h>
-#include "variant.h"
-#include <due_can.h>
-#define Serial SerialUSB
-				
-	
-class ISA : public CANListener
+#include "../miwagner-ESP32-Arduino-CAN/CAN_config.h"
+#include "../miwagner-ESP32-Arduino-CAN/ESP32CAN.h"
+
+class ISA 
 {
 	
 	
@@ -67,13 +64,11 @@ class ISA : public CANListener
 		long lastAs;
 		long wh;
   		long lastWh;	
-		CANRaw *canPort;
-		uint8_t canEnPin;
-		int canSpeed;
+		void handleFrame(CAN_frame_t *frame); // CAN handler
 		uint8_t page;
 		
 	private:
-      	CAN_FRAME frame;
+		CAN_frame_t frame;
 		unsigned long elapsedtime;
 		double  ampseconds;
 		int milliseconds ;
@@ -83,18 +78,25 @@ class ISA : public CANListener
 		char buffer[9];
 		char bigbuffer[90];
 		uint32_t inbox;
-		CAN_FRAME outframe;
+		CAN_frame_t outframe = {.FIR = {.B =
+                                       {
+                                           .DLC = 8,
+                                           .FF = CAN_frame_std,
+                                       }},
+                           .MsgID = 0x411,
+                           .data = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+
+
 		
-		void gotFrame(CAN_FRAME *frame, int mailbox); // CAN interrupt service routine	
-		void printCAN(CAN_FRAME *frame);
-		void handle521(CAN_FRAME *frame);
-		void handle522(CAN_FRAME *frame);
-		void handle523(CAN_FRAME *frame);
-		void handle524(CAN_FRAME *frame);
-		void handle525(CAN_FRAME *frame);
-		void handle526(CAN_FRAME *frame);
-		void handle527(CAN_FRAME *frame);
-		void handle528(CAN_FRAME *frame);
+		void printCAN(CAN_frame_t *frame);
+		void handle521(CAN_frame_t *frame);
+		void handle522(CAN_frame_t *frame);
+		void handle523(CAN_frame_t *frame);
+		void handle524(CAN_frame_t *frame);
+		void handle525(CAN_frame_t *frame);
+		void handle526(CAN_frame_t *frame);
+		void handle527(CAN_frame_t *frame);
+		void handle528(CAN_frame_t *frame);
 		
 								
 };


### PR DESCRIPTION
Conversion was deliberately lightweight..Preserves warts-and-all from original upstream (e.g., whitespace inconsistencies, naming/structural oddities, etc) to keep delta in this fork minimal for maintenance and simpler upstream tracking.